### PR TITLE
Fault scenarios

### DIFF
--- a/src/run_sim.jl
+++ b/src/run_sim.jl
@@ -7,12 +7,12 @@ function sample(multicopter::Multicopter, min_nt, max_nt)
     (p, v, R, ω,)  # tuple; args_multicopter
 end
 
-function run_sim(method, args_multicopter, multicopter, faults, fdi::FTC.DelayFDI, θs, tf, dir_log;
-        t0=0.0,
+function run_sim(method, args_multicopter, multicopter, faults, fdi::FTC.DelayFDI, traj_des, dir_log;
+        t0=0.0, tf=20.0,
         savestep=0.01,
         will_plot=false,
     )
-    pos_cmd_func = Bezier(θs; tf=tf)
+    pos_cmd_func(t) = traj_des(t)
     mkpath(dir_log)
     file_path = joinpath(dir_log, TRAJ_DATA_NAME)
     @show file_path
@@ -88,10 +88,11 @@ function run_sim(method, args_multicopter, multicopter, faults, fdi::FTC.DelayFD
         FileIO.save(file_path, Dict(
                                     "df" => df,
                                     "method" => String(method),
-                                    "tf" => tf,
-                                    "θs" => θs,
-                                    "fdi" => fdi,
                                     "faults" => faults,
+                                    "fdi" => fdi,
+                                    "t0" => t0,
+                                    "tf" => tf,
+                                    "traj_des" => traj_des,
                                    ))
     # end
     saved_data = JLD2.load(file_path)
@@ -104,8 +105,8 @@ end
 
 function plot_figures(multicopter, dir_log, saved_data)
     @unpack u_min, u_max, dim_input = multicopter
-    @unpack df, method, θs, tf = saved_data
-    pos_cmd_func = Bezier(θs; tf=tf)
+    @unpack df, method, traj_des = saved_data
+    pos_cmd_func(t) = traj_des(t)
     # data
     ts = df.time
     poss = df.sol |> Map(datum -> datum.plant.state.p) |> collect

--- a/src/run_sim.jl
+++ b/src/run_sim.jl
@@ -12,7 +12,6 @@ function run_sim(method, args_multicopter, multicopter, faults, fdi::FTC.DelayFD
         savestep=0.01,
         will_plot=false,
     )
-    @unpack τ = fdi
     pos_cmd_func = Bezier(θs; tf=tf)
     mkpath(dir_log)
     file_path = joinpath(dir_log, TRAJ_DATA_NAME)
@@ -91,7 +90,7 @@ function run_sim(method, args_multicopter, multicopter, faults, fdi::FTC.DelayFD
                                     "method" => String(method),
                                     "tf" => tf,
                                     "θs" => θs,
-                                    "τ" => τ,
+                                    "fdi" => fdi,
                                     "faults" => faults,
                                    ))
     # end
@@ -99,6 +98,7 @@ function run_sim(method, args_multicopter, multicopter, faults, fdi::FTC.DelayFD
     if will_plot
         plot_figures(multicopter, dir_log, saved_data, θs, tf)
     end
+    saved_data
 end
 
 

--- a/src/run_sim.jl
+++ b/src/run_sim.jl
@@ -87,6 +87,8 @@ function run_sim(method, args_multicopter, multicopter, faults, fdi, θs, tf, di
         FileIO.save(file_path, Dict(
                                     "df" => df,
                                     "method" => String(method),
+                                    "tf" => tf,
+                                    "θs" => θs,
                                    ))
     # end
     saved_data = JLD2.load(file_path)

--- a/src/run_sim.jl
+++ b/src/run_sim.jl
@@ -7,14 +7,16 @@ function sample(multicopter::Multicopter, min_nt, max_nt)
     (p, v, R, ω,)  # tuple; args_multicopter
 end
 
-function run_sim(method, args_multicopter, multicopter, faults, fdi, θs, tf, dir_log;
+function run_sim(method, args_multicopter, multicopter, faults, fdi::FTC.DelayFDI, θs, tf, dir_log;
         t0=0.0,
         savestep=0.01,
         will_plot=false,
     )
+    @unpack τ = fdi
     pos_cmd_func = Bezier(θs; tf=tf)
     mkpath(dir_log)
     file_path = joinpath(dir_log, TRAJ_DATA_NAME)
+    @show file_path
     saved_data = nothing
     data_exists = isfile(file_path)
     # if !data_exists
@@ -89,6 +91,8 @@ function run_sim(method, args_multicopter, multicopter, faults, fdi, θs, tf, di
                                     "method" => String(method),
                                     "tf" => tf,
                                     "θs" => θs,
+                                    "τ" => τ,
+                                    "faults" => faults,
                                    ))
     # end
     saved_data = JLD2.load(file_path)

--- a/src/run_sim.jl
+++ b/src/run_sim.jl
@@ -97,7 +97,7 @@ function run_sim(method, args_multicopter, multicopter, faults, fdi::FTC.DelayFD
     # end
     saved_data = JLD2.load(file_path)
     if will_plot
-        plot_figures(multicopter, dir_log, saved_data, θs, tf)
+        plot_figures(multicopter, dir_log, saved_data)
     end
     saved_data
 end

--- a/src/run_sim.jl
+++ b/src/run_sim.jl
@@ -98,9 +98,9 @@ function run_sim(method, args_multicopter, multicopter, faults, fdi, θs, tf, di
 end
 
 
-function plot_figures(multicopter, dir_log, saved_data, θs, tf)
+function plot_figures(multicopter, dir_log, saved_data)
     @unpack u_min, u_max, dim_input = multicopter
-    @unpack df, method = saved_data
+    @unpack df, method, θs, tf = saved_data
     pos_cmd_func = Bezier(θs; tf=tf)
     # data
     ts = df.time

--- a/test/run_multiple_sim.jl
+++ b/test/run_multiple_sim.jl
@@ -87,14 +87,16 @@ function run_multiple_sim(N=1; collector=Transducers.tcollect, will_plot=false, 
     τs = 1:N |> Map(i -> rand([0.0, 0.1])) |> collect  # FDI delay (0.0 or 0.1s)
     θs = [[0, 0, -10.0]]  # constant position tracking
     # θs = [[0, 0, 0], [3, 4, 5], [2, 1, -3]]  # Bezier curve
-    tf = 20.0
+    t0, tf = 0.0, 20.0
+    traj_des = Bezier(θs, t0, tf)
     # run sim and save fig
     for method in [:adaptive, :adaptive2optim]
         for manoeuvre in [:hovering, :forward]
             x0s = 1:N |> Map(i -> FTCTests.sample(multicopter, distribution_info(manoeuvre)...)) |> collect
             dir_log = joinpath(joinpath(_dir_log, String(method)), String(manoeuvre))
             @time saved_data_array = zip(1:N, x0s, _faults, τs) |> MapSplat((i, x0, _fault, τ) ->
-                                                                            FTCTests.run_sim(method, x0, multicopter, FaultSet(_fault...), DelayFDI(τ), θs, tf, joinpath(dir_log, lpad(string(i), 4, '0')); will_plot=will_plot)) |> collector
+                                                                            FTCTests.run_sim(method, x0, multicopter, FaultSet(_fault...), DelayFDI(τ), traj_des, joinpath(dir_log, lpad(string(i), 4, '0'));
+                                                                                             will_plot=will_plot, t0=t0, tf=tf)) |> collector
         end
     end
     nothing

--- a/test/run_multiple_sim.jl
+++ b/test/run_multiple_sim.jl
@@ -7,18 +7,25 @@ using Random
 euler = [ψ, θ, ϕ]  # yaw, pitch, roll
 """
 function distribution_info(manoeuvre::Symbol)
-    p_min, p_max = [-1, -1, -11.0], [1, 1, -9.0]
+    p_min, p_max = nothing, nothing
     v_min, v_max = nothing, nothing
     euler_min, euler_max = nothing, nothing
     ω_min, ω_max = nothing, nothing
     if manoeuvre == :hovering
+        p_min, p_max = [-1, -1, -11.0], [1, 1, -9.0]
         v_min, v_max = [-1, -1, -1.0], [1, 1, 1.0]
         euler_min, euler_max = [deg2rad(-5), deg2rad(-5), deg2rad(-5)], [deg2rad(5), deg2rad(5), deg2rad(5)]
         ω_min, ω_max = [deg2rad(-5), deg2rad(-5), deg2rad(-5)], [deg2rad(5), deg2rad(5), deg2rad(5)]
     elseif manoeuvre == :forward
+        p_min, p_max = [-1, -1, -11.0], [1, 1, -9.0]
         v_min, v_max = [3, -1, -1.0], [7, 1, 1.0]
         euler_min, euler_max = [deg2rad(-2), deg2rad(-10), deg2rad(-2)], [deg2rad(2), deg2rad(-5), deg2rad(2)]
         ω_min, ω_max = [deg2rad(-2), deg2rad(-2), deg2rad(-2)], [deg2rad(2), deg2rad(2), deg2rad(2)]
+    elseif manoeuvre == :debug
+        p_min, p_max = [0, 0, -10.0], [0, 0, -10.0]
+        v_min, v_max = zeros(3), zeros(3)
+        euler_min, euler_max = zeros(3), zeros(3)
+        ω_min, ω_max = zeros(3), zeros(3)
     else
         error("Invalid manoeuvre")
     end
@@ -91,6 +98,7 @@ function run_multiple_sim(N=1; collector=Transducers.tcollect, will_plot=false, 
     traj_des = Bezier(θs, t0, tf)
     # run sim and save fig
     for method in [:adaptive, :adaptive2optim]
+        # for manoeuvre in [:debug]
         for manoeuvre in [:hovering, :forward]
             x0s = 1:N |> Map(i -> FTCTests.sample(multicopter, distribution_info(manoeuvre)...)) |> collect
             dir_log = joinpath(joinpath(_dir_log, String(method)), String(manoeuvre))

--- a/test/run_multiple_sim.jl
+++ b/test/run_multiple_sim.jl
@@ -39,10 +39,17 @@ end
 
 
 """
+    run_multiple_sim()
+
+A function for running multiple simulation.
+This is used for 2nd-year report.
+
+# Notes
 collector = collect (sequential computing)
 collector = Transducers.tcollect (parallel computing)
 """
 function run_multiple_sim(N=1; collector=Transducers.tcollect, will_plot=false, seed=2021)
+    println("Simulation case: $(N)")
     if collector == tcollect
         println("Parallel computing...")
         will_plot == true ? error("plotting figures not supported in tcollect") : nothing
@@ -52,25 +59,44 @@ function run_multiple_sim(N=1; collector=Transducers.tcollect, will_plot=false, 
         error("Invalid collector")
     end
     Random.seed!(seed)
-    dir_log = "data"
+    _dir_log = "data"
     # methods = [:adaptive, :optim, :adaptive2optim]
-    method = :adaptive
-    manoeuvre = :forward
-    multicopter = LeeHexacopter()  # dummy
-    faults = FaultSet(
-                      LoE(3.0, 1, 0.0),
-                      LoE(3.0, 3, 0.0),  # t, index, level
-                     )  # Note: antisymmetric configuration of faults can cause undesirable control allocation; sometimes it is worse than multiple faults of rotors in symmetric configuration.
-    τ = 0.0
-    fdi = DelayFDI(τ)
-    θs = [[0, 0, -10.0]]  # constant position tracking
-    # θs = [[0, 0, 0], [3, 4, 5], [2, 1, -3]]  # Bezier curve
-    tf = 20.0
-    # run sim and save fig
-    min_nt, max_nt = distribution_info(manoeuvre)
-    x0s = 1:N |> Map(i -> FTCTests.sample(multicopter, min_nt, max_nt)) |> collect
-    @time saved_data_array = zip(1:N, x0s) |> MapSplat((i, x0) ->
-                                                       FTCTests.run_sim(method, x0, multicopter, faults, fdi, θs, tf,
-                                                               joinpath(dir_log, lpad(string(i), 4, '0')); will_plot=will_plot)) |> collector
+    for method in [:adaptive, :adaptive2optim]
+        dir_log = joinpath(_dir_log, String(method))
+        manoeuvre = :forward
+        multicopter = LeeHexacopter()  # dummy
+        fault_time = 3.0
+        _fault_list_single = [[
+                              [LoE(fault_time, index, effectiveness)]
+                              for index in 1:6
+                              for effectiveness in [0.9, 0.5, 0.1, 0.0]
+                             ]...]
+        _fault_list_double = [[
+                              [LoE(fault_time, index, effectiveness),
+                               LoE(fault_time, index2, effectiveness)]
+                              for index in 1:5
+                              for index2 in index+1:6
+                              for effectiveness in [0.9, 0.5, 0.1, 0.0]
+                             ]...]
+        _fault_list_single_failure_single_fault = [[
+                                                   [LoE(fault_time, index, 0.0),
+                                                    LoE(fault_time, index2, effectiveness)]
+                                                   for index in 1:6
+                                                   for index2 in filter(x -> x != index, 1:6)
+                                                   for effectiveness in [0.9, 0.5, 0.1]
+                                                  ]...]
+        _fault_list = [_fault_list_single..., _fault_list_double..., _fault_list_single_failure_single_fault...]
+        _faults = 1:N |> Map(i -> rand(_fault_list)) |> collect  # randomly sampled N faults
+        τs = 1:N |> Map(i -> rand([0.0, 0.1])) |> collect  # FDI delay (0.0 or 0.1s)
+        θs = [[0, 0, -10.0]]  # constant position tracking
+        # θs = [[0, 0, 0], [3, 4, 5], [2, 1, -3]]  # Bezier curve
+        tf = 20.0
+        # run sim and save fig
+        min_nt, max_nt = distribution_info(manoeuvre)
+        x0s = 1:N |> Map(i -> FTCTests.sample(multicopter, min_nt, max_nt)) |> collect
+        @time saved_data_array = zip(1:N, x0s, _faults, τs) |> MapSplat((i, x0, _fault, τ) ->
+                                                                   FTCTests.run_sim(method, x0, multicopter, FaultSet(_fault...), DelayFDI(τ), θs, tf,
+                                                                   joinpath(dir_log, lpad(string(i), 4, '0')); will_plot=will_plot)) |> collector
+    end
     nothing
 end


### PR DESCRIPTION
Resolves #2, #6

# Notes
## 주의
- 병렬 시뮬레이션을 위해, `julia -t 24` 와 같이 멀티 쓰레드를 활성화해주세요. `-t` 옵션 뒤에 붙는 것은 활성화할 쓰레드의 개수입니다.
- 가장 최신의 FTC.jl master 브랜치를 사용해야합니다 ([FTC.jl, #55](https://github.com/JinraeKim/FaultTolerantControl.jl/pull/55)이후).

## Running simulation
`include("test/run_multiple_sim.jl")`
`run_multiple_sim(N)`  (N 은 원하는 시뮬레이션 숫자)
이때, 랜덤하게 `N`개의 시뮬레이션 조건을 생성한 뒤, `method_list = [:adaptive, :adaptive2optim]` 내의 모든 기법 및 `manouvre_list = [:hovering, :forward]` 내의 모든 기동에 대해 시뮬을 각각 돌려서 결과를 얻습니다.

아래와 같은 경로로 데이터가 저장되며, 참고로 `adaptive2optim` (switching) 의 경우 최적화때문에 시뮬레이션이 오래 걸릴 수 있으니 참고 바랍니다.
```julia
Simulation case: 1
Parallel computing...
file_path = "data/adaptive/hovering/0001/traj.jld2"
  2.209371 seconds (16.62 M allocations: 1.089 GiB, 8.81% gc time, 7.72% compilation time)
file_path = "data/adaptive/forward/0001/traj.jld2"
  1.976580 seconds (16.72 M allocations: 1.104 GiB, 6.85% gc time)
file_path = "data/adaptive2optim/hovering/0001/traj.jld2"
 12.475057 seconds (61.77 M allocations: 3.702 GiB, 6.04% gc time)
file_path = "data/adaptive2optim/forward/0001/traj.jld2"
 13.534704 seconds (62.95 M allocations: 3.772 GiB, 6.53% gc time)
```

## Faults
### Fault list
다음 list 에서 랜덤하게 뽑아서 시뮬을 돌리게 됩니다.
```julia
        _fault_list = [_fault_list_single..., _fault_list_double..., _fault_list_single_failure_single_fault...]
```
Single fault 는 아래와 같으며, 자세한 고장 목록에 대한 설명은 #2 를 참고해주세요.
```julia
        fault_time = 3.0
        _fault_list_single = [[
                              [LoE(fault_time, index, effectiveness)]
                              for index in 1:6
                              for effectiveness in [0.9, 0.5, 0.1, 0.0]
                             ]...]
```
(4개 effectivness, 6개 로터 -> 24개)
```julia
24-element Vector{Vector{LoE}}:
 [LoE(3.0, 1, 0.9)]
 [LoE(3.0, 1, 0.5)]
 [LoE(3.0, 1, 0.1)]
 [LoE(3.0, 1, 0.0)]
 [LoE(3.0, 2, 0.9)]
 [LoE(3.0, 2, 0.5)]
 [LoE(3.0, 2, 0.1)]
 [LoE(3.0, 2, 0.0)]
 [LoE(3.0, 3, 0.9)]
 [LoE(3.0, 3, 0.5)]
 [LoE(3.0, 3, 0.1)]
 [LoE(3.0, 3, 0.0)]
 [LoE(3.0, 4, 0.9)]
 [LoE(3.0, 4, 0.5)]
 [LoE(3.0, 4, 0.1)]
 [LoE(3.0, 4, 0.0)]
 [LoE(3.0, 5, 0.9)]
 [LoE(3.0, 5, 0.5)]
 [LoE(3.0, 5, 0.1)]
 [LoE(3.0, 5, 0.0)]
 [LoE(3.0, 6, 0.9)]
 [LoE(3.0, 6, 0.5)]
 [LoE(3.0, 6, 0.1)]
 [LoE(3.0, 6, 0.0)]

```

```julia
    _fault_list_double = [[
                          [LoE(fault_time, index, effectiveness),
                           LoE(fault_time, index2, effectiveness)]
                          for index in 1:5
                          for index2 in index+1:6
                          for effectiveness in [0.9, 0.5, 0.1, 0.0]
                         ]...]

```
(4개 effectivness, 6개 로터 2쌍씩 6C2=15 -> 60개)
```julia
60-element Vector{Vector{LoE}}:
 [LoE(3.0, 1, 0.9), LoE(3.0, 2, 0.9)]
 [LoE(3.0, 1, 0.5), LoE(3.0, 2, 0.5)]
 [LoE(3.0, 1, 0.1), LoE(3.0, 2, 0.1)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 2, 0.0)]
 [LoE(3.0, 1, 0.9), LoE(3.0, 3, 0.9)]
 [LoE(3.0, 1, 0.5), LoE(3.0, 3, 0.5)]
 [LoE(3.0, 1, 0.1), LoE(3.0, 3, 0.1)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 3, 0.0)]
 [LoE(3.0, 1, 0.9), LoE(3.0, 4, 0.9)]
 [LoE(3.0, 1, 0.5), LoE(3.0, 4, 0.5)]
 [LoE(3.0, 1, 0.1), LoE(3.0, 4, 0.1)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 4, 0.0)]
 [LoE(3.0, 1, 0.9), LoE(3.0, 5, 0.9)]
 [LoE(3.0, 1, 0.5), LoE(3.0, 5, 0.5)]
 ⋮
 [LoE(3.0, 3, 0.0), LoE(3.0, 6, 0.0)]
 [LoE(3.0, 4, 0.9), LoE(3.0, 5, 0.9)]
 [LoE(3.0, 4, 0.5), LoE(3.0, 5, 0.5)]
 [LoE(3.0, 4, 0.1), LoE(3.0, 5, 0.1)]
 [LoE(3.0, 4, 0.0), LoE(3.0, 5, 0.0)]
 [LoE(3.0, 4, 0.9), LoE(3.0, 6, 0.9)]
 [LoE(3.0, 4, 0.5), LoE(3.0, 6, 0.5)]
 [LoE(3.0, 4, 0.1), LoE(3.0, 6, 0.1)]
 [LoE(3.0, 4, 0.0), LoE(3.0, 6, 0.0)]
 [LoE(3.0, 5, 0.9), LoE(3.0, 6, 0.9)]
 [LoE(3.0, 5, 0.5), LoE(3.0, 6, 0.5)]
 [LoE(3.0, 5, 0.1), LoE(3.0, 6, 0.1)]
 [LoE(3.0, 5, 0.0), LoE(3.0, 6, 0.0)]
```

```julia
    _fault_list_single_failure_single_fault = [[
                                               [LoE(fault_time, index, 0.0),
                                                LoE(fault_time, index2, effectiveness)]
                                               for index in 1:6
                                               for index2 in filter(x -> x != index, 1:6)
                                               for effectiveness in [0.9, 0.5, 0.1]
                                              ]...]

```
(1개 로터  failure 로 고정 (6개), 나머지 로터 선택 (5개), 그 로터의 effectiveness 3 종류 (완전고장 제외) -> 90개)
```julia
90-element Vector{Vector{LoE}}:
 [LoE(3.0, 1, 0.0), LoE(3.0, 2, 0.9)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 2, 0.5)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 2, 0.1)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 3, 0.9)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 3, 0.5)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 3, 0.1)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 4, 0.9)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 4, 0.5)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 4, 0.1)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 5, 0.9)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 5, 0.5)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 5, 0.1)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 6, 0.9)]
 [LoE(3.0, 1, 0.0), LoE(3.0, 6, 0.5)]
 ⋮
 [LoE(3.0, 6, 0.0), LoE(3.0, 1, 0.1)]
 [LoE(3.0, 6, 0.0), LoE(3.0, 2, 0.9)]
 [LoE(3.0, 6, 0.0), LoE(3.0, 2, 0.5)]
 [LoE(3.0, 6, 0.0), LoE(3.0, 2, 0.1)]
 [LoE(3.0, 6, 0.0), LoE(3.0, 3, 0.9)]
 [LoE(3.0, 6, 0.0), LoE(3.0, 3, 0.5)]
 [LoE(3.0, 6, 0.0), LoE(3.0, 3, 0.1)]
 [LoE(3.0, 6, 0.0), LoE(3.0, 4, 0.9)]
 [LoE(3.0, 6, 0.0), LoE(3.0, 4, 0.5)]
 [LoE(3.0, 6, 0.0), LoE(3.0, 4, 0.1)]
 [LoE(3.0, 6, 0.0), LoE(3.0, 5, 0.9)]
 [LoE(3.0, 6, 0.0), LoE(3.0, 5, 0.5)]
 [LoE(3.0, 6, 0.0), LoE(3.0, 5, 0.1)]

```


### Load data
fault 는 다음과 같이 저장됩니다.
```julia
julia> JLD2.load("data/adaptive/0001/traj.jld2")["faults"]
2-element Vector{AbstractFault}:
 LoE(3.0, 1, 0.0)
 LoE(3.0, 6, 0.9)
```
회복률 테이블 같은걸 만들 때, 해당 LoE 로 구성된 array로부터 string 을 뽑아내면 되겠죠? 위의 예시라면 뭐 예를 들어 `rotor1_effectiveness_000_rotor2_effectiveness_090` 이런 식으로 ㅎㅎ
LoE의 정의는 [FaultTolerantControl.jl 내의 정의](https://github.com/JinraeKim/FaultTolerantControl.jl/blob/3ae10ce8bdbd3c4fc8b871112bc87c77d8cf0483/src/faults.jl#L47) 를 봐주세요.

```julia
julia> JLD2.load("data/adaptive/forward/0001/traj.jld2")["faults"]
2-element Vector{AbstractFault}:
 LoE(3.0, 1, 0.0)
 LoE(3.0, 6, 0.9)
```

## FDI delay
```julia
julia> JLD2.load("data/adaptive/forward/0001/traj.jld2")["fdi"]
DelayFDI(0.1)
```
비슷하게 DelayFDI의 정의는 [FaultTolerantControl.jl 내의 정의](https://github.com/JinraeKim/FaultTolerantControl.jl/blob/3ae10ce8bdbd3c4fc8b871112bc87c77d8cf0483/src/environments/FDI/DelayFDI.jl#L5)를 봐주세요.

## 기타
기타 저장한 데이터를 불러올 때는, `src/run_sim.jl` 의 마지막 부분을 참고해주세요.
예를 들어, 현재는
```julia
        FileIO.save(file_path, Dict(
                                    "df" => df,
                                    "method" => String(method),
                                    "faults" => faults,
                                    "fdi" => fdi,
                                    "t0" => t0,
                                    "tf" => tf,
                                    "traj_des" => traj_des,
                                   ))
```
와 같습니다.
JLD2 로 데이터를 읽을 때, reconstruction 오류를 방지하기 위해서는 "데이터를 불러오는 함수를 `src` 내에 작성하는 것"이 좋습니다.
TMI: reconstruction 을 위해 type 에 대한 정보 (예: DelayFDI) 등이 필요하며, 이는 FTCTests 가 읽어들이는 FaultTolerantControl 에 모드 있으므로 이를 권장함