### PR TITLE
시뮬레이션이 멈추는 현상 방지 (loss of height 에서 강제 종료)

### DIFF
--- a/main/run_multiple_sim.jl
+++ b/main/run_multiple_sim.jl
@@ -58,6 +58,8 @@ This is used for 2nd-year report.
 - manoeuvre = :hovering or :forward (:debug for debugging)
 """
 function run_multiple_sim(manoeuvre::Symbol, N=1;
+        h_threshold=5.0,  # m
+        actual_time_limit=60.0,  # s
         N_thread=Threads.nthreads(),
         collector=Transducers.tcollect, will_plot=false, seed=2021)
     println("Simulation case: $(N)")
@@ -118,7 +120,10 @@ function run_multiple_sim(manoeuvre::Symbol, N=1;
                                                             DelayFDI(τ),
                                                             traj_des, dir_log, i;
                                                             will_plot=will_plot,
-                                                            t0=t0, tf=tf)) |> collector
+                                                            t0=t0, tf=tf,
+                                                            h_threshold=h_threshold,
+                                                            actual_time_limit=actual_time_limit,
+                                                           )) |> collector
         end
     end
     nothing

--- a/src/run_sim.jl
+++ b/src/run_sim.jl
@@ -13,7 +13,8 @@ function run_sim(method, args_multicopter, multicopter::FlightSims.Multicopter,
         t0=0.0, tf=20.0,
         savestep=0.01,
         will_plot=false,
-        h_threshold=5.0,
+        h_threshold=nothing,
+        actual_time_limit=nothing,
     )
     pos_cmd_func(t) = traj_des(t)
     mkpath(dir_log)
@@ -78,29 +79,49 @@ function run_sim(method, args_multicopter, multicopter::FlightSims.Multicopter,
             end
         end
         cb_switch = DiscreteCallback(condition, affect!)
-        # termination
-        function terminate_condition(X, t, integrator)
-            @unpack p = X.plant.multicopter
-            h = -p[3]  # h = -z
-            h < h_threshold
-        end
+        cbs = Any[cb_switch]
         simulation_success = true
-        function terminate_affect!(integrator)
-            simulation_success = false
-            @warn("Simulation is terminated due to the loss of height")
-            terminate!(integrator)
+        # termination
+        if h_threshold != nothing
+            function terminate_condition(X, t, integrator)
+                @unpack p = X.plant.multicopter
+                h = -p[3]  # h = -z
+                h < h_threshold
+            end
+            function terminate_affect!(integrator)
+                simulation_success = false
+                @warn("Simulation is terminated due to the loss of height")
+                terminate!(integrator)
+            end
+            cb_terminate = DiscreteCallback(terminate_condition, terminate_affect!)
+            push!(cbs, cb_terminate)
         end
-        cb_terminate = DiscreteCallback(terminate_condition, terminate_affect!)
-        cb = CallbackSet(cb_switch, cb_terminate)
+        _t0 = time()
+        if actual_time_limit != nothing
+            @assert actual_time_limit > 0.0
+            function terminate_condition_time(X, t, integrator)
+                _t = time()
+                (_t - _t0) > actual_time_limit
+            end
+            function terminate_affect_time!(integrator)
+                simulation_success = false
+                @warn("Simulation is terminated 'cause it exceeds the actual time limit of $(actual_time_limit) [s]")
+                terminate!(integrator)
+            end
+            cb_terminate_time = DiscreteCallback(terminate_condition_time, terminate_affect_time!)
+            push!(cbs, cb_terminate_time)
+        end
+        cb = CallbackSet(cbs...)
         # sim
         simulator = Simulator(
                               x0, dynamics!, p0;
                               t0=t0, tf=tf,
                              )
+        # TODO: time exceed should be in `solve` for properly measuring elapsed time
         df = solve(simulator;
-                         savestep=savestep,
-                         callback=cb,
-                        )
+                   savestep=savestep,
+                   callback=cb,
+                  )
         FileIO.save(file_path, Dict(
                                     "df" => df,
                                     "method" => String(method),
@@ -381,4 +402,5 @@ function plot_figures(multicopter, dir_log, saved_data)
            label="ψ (deg)",
           )
      savefig(p_euler, joinpath(dir_log, "euler.pdf"))
+     savefig(p_euler, joinpath(dir_log, "euler.png"))
 end

--- a/src/run_sim.jl
+++ b/src/run_sim.jl
@@ -80,7 +80,6 @@ function run_sim(method, args_multicopter, multicopter::FlightSims.Multicopter,
         cb_switch = DiscreteCallback(condition, affect!)
         # termination
         function terminate_condition(X, t, integrator)
-            @show X
             @unpack p = X.plant.multicopter
             h = -p[3]  # h = -z
             h < h_threshold
@@ -88,6 +87,7 @@ function run_sim(method, args_multicopter, multicopter::FlightSims.Multicopter,
         simulation_success = true
         function terminate_affect!(integrator)
             simulation_success = false
+            @warn("Simulation is terminated due to the loss of height")
             terminate!(integrator)
         end
         cb_terminate = DiscreteCallback(terminate_condition, terminate_affect!)

--- a/test/run_sim.jl
+++ b/test/run_sim.jl
@@ -1,3 +1,6 @@
+using Test
+
+
 @testset "run_sim" begin
     dir_log = "__data__"
     case_number = 1
@@ -13,5 +16,5 @@
     θs = [[0, 0, 0.0]]  # constant position tracking
     traj_des = Bezier(θs, t0, tf)
     run_sim(method, args_multicopter, multicopter, fault, fdi, traj_des, dir_log, case_number;
-            t0=t0, tf=tf, savestep=0.01, will_plot=true,)
+            t0=t0, tf=tf, savestep=0.01, will_plot=true)
 end


### PR DESCRIPTION
Resolves #22.

@hnlee77 다음과 같이 `simulation_success` 를 추가로 저장합니다.
```julia
Dict{String, Any} with 8 entries:
  "t0"                 => 0.0
  "faults"             => AbstractFault[LoE(0.0, 1, 0.0), LoE(0.0, 6, 0.9)]
  "method"             => "adaptive"
  "simulation_success" => true
  "df"                 => 2001×2 DataFrame…
  "tf"                 => 20.0
  "fdi"                => DelayFDI(0.1)
  "traj_des"           => Bezier([[0.0, 0.0, -10.0]], 0.0, 20.0)
```



실패 경우에 대해 그래프를 출력한 결과입니다 (고도 5m 보다 낮을 때 종료):
![input](https://user-images.githubusercontent.com/43136096/147046837-b9e9b432-c4c8-413a-830e-eafa57ab2001.png)
![state](https://user-images.githubusercontent.com/43136096/147046842-41e6bd3e-8c48-4d6a-8cf9-79b3eb98d20e.png)

실패 케이스 저장 예시입니다:
```julia
julia> JLD2.load("data/forward/adaptive/0010_traj.jld2")
Dict{String, Any} with 8 entries:
  "t0"                 => 0.0
  "faults"             => AbstractFault[LoE(0.0, 1, 0.1), LoE(0.0, 6, 0.1)]
  "method"             => "adaptive"
  "simulation_success" => false
  "df"                 => 194×2 DataFrame…
  "tf"                 => 20.0
  "fdi"                => DelayFDI(0.1)
  "traj_des"           => Bezier([[0.0, 0.0, -10.0]], 0.0, 20.0)

```
