### PR TITLE
Fix a little bug

### DIFF
--- a/main/compute_recovery_rate.jl
+++ b/main/compute_recovery_rate.jl
@@ -21,7 +21,7 @@ function _file_path_to_nt(file_path::String, t1, threshold)
             is_success = evaluate(jld2, t1, threshold)
         end
     else
-        is_success = missing  # not considered as either true or false
+        is_success = false  # not considered as either true or false
     end
     _nt = (;
            fault=extract_fault_property(faults),

--- a/main/compute_recovery_rate.jl
+++ b/main/compute_recovery_rate.jl
@@ -16,7 +16,7 @@ function _file_path_to_nt(file_path::String, t1, threshold)
     @unpack faults, fdi, simulation_height_success, simulation_actual_time_success = jld2
     if simulation_actual_time_success == true
         if simulation_height_success == false
-            is_success = false
+            is_success = missing
         else
             is_success = evaluate(jld2, t1, threshold)
         end
@@ -41,7 +41,7 @@ function compute_recovery_rate(; _dir_log="data", t1=15.0, threshold=0.1)
             dir_log = joinpath(joinpath(_dir_log, String(manoeuvre)), String(method))
             file_paths = readdir(dir_log; join=true)
             _ = file_paths |> Map(file_path ->
-                                  push!(_df, _file_path_to_nt(file_path, t1, threshold))
+                                  push!(_df, _file_path_to_nt(file_path, t1, threshold); promote=true)
                                  ) |> collect
             _df_simtime = filter(:sim_time_success => t -> t == true, _df)
             # group by FDI delay
@@ -58,7 +58,7 @@ function compute_recovery_rate(; _dir_log="data", t1=15.0, threshold=0.1)
                                fault_kind=df_fault_kind.fault_kind[1],  # the same fault kind
                                recovery_rate=recovery_rate,
                                num=length(df_fault_kind.is_success)
-                              ))
+                              ); promote=true)
                 end
             end
         end

--- a/main/compute_recovery_rate.jl
+++ b/main/compute_recovery_rate.jl
@@ -16,12 +16,12 @@ function _file_path_to_nt(file_path::String, t1, threshold)
     @unpack faults, fdi, simulation_height_success, simulation_actual_time_success = jld2
     if simulation_actual_time_success == true
         if simulation_height_success == false
-            is_success = missing
+            is_success = false
         else
             is_success = evaluate(jld2, t1, threshold)
         end
     else
-        is_success = false  # not considered as either true or false
+        is_success = missing  # not considered as either true or false
     end
     _nt = (;
            fault=extract_fault_property(faults),


### PR DESCRIPTION
맥에서 나는 오류를 잡다보니.. `convert`오류가 나는 것이 `is_success`를 dataframe에 push할 때에 오류가 나는 것을 확인하였습니다.
이것이 `is_success = missing`이 되는 경우에 오류가 나서 값을 `false`로 수정하였는데요. `missing`이나 `none` 등 의미가 없는 값을 넣을 수 있는 방법이 있는지 잘 모르겠습니다. 어제 시뮬레이션에서 오류가 나지 않았다고 말씀드렸었는데, 그 이유는 REPL을 끄지 않은 상태에서 계속 작업을 하다가 회복률을 계산하니 time_limit에 걸린 데이터가 없어서 아마 괜찮았던 것 같습니다. 새로 데이터를 뽑아서 확인해보니 time_limit에 걸리면서 오류가 생기네요.