### PR TITLE
Add `run_multiple_sim_training_cost`

### DIFF
--- a/main/run_multiple_sim_training_cost.jl
+++ b/main/run_multiple_sim_training_cost.jl
@@ -1,0 +1,35 @@
+using FTCTests  # reexport FaulTolerantControl
+using Transducers
+using Random
+using Test
+
+
+"""
+This is for the training of cost function.
+"""
+function run_multiple_sim_training_cost(N=1;
+        manoeuvres=[:debug],
+        methods=[:adaptive],
+        t0=0.0, tf=20.0,
+        h_threshold=5.0,  # m (nothing: no constraint)
+        actual_time_limit=nothing,  # s (nothing: no constraint)
+        N_thread=Threads.nthreads(),
+        collector=Transducers.tcollect, will_plot=false, seed=2021,
+    )
+    fault_time = 0.0
+    # single fault
+    # rotor index ∈ {1, 2, 3, 4, 5, 6}
+    # effectiveness ∈ [0, 1]
+    _faults = 1:N |> Map(i -> [LoE(fault_time, rand(1:6), rand(1)[1])]) |> collect  # randomly sampled N faults
+    θs = [[0, 0, 0.0]]  # Control points of Bezier curve; constant position tracking
+    θs_array = 1:N |> Map(i -> θs) |> collect
+    run_multiple_sim(N,
+                     manoeuvres,
+                     methods,
+                     _faults,
+                     θs_array,
+                     t0, tf,
+                     h_threshold, actual_time_limit, N_thread, collector,
+                     will_plot, seed
+                    )
+end

--- a/main/run_multiple_sim_training_cost.jl
+++ b/main/run_multiple_sim_training_cost.jl
@@ -11,7 +11,7 @@ function run_multiple_sim_training_cost(N=1;
         manoeuvres=[:debug],
         methods=[:adaptive],
         t0=0.0, tf=20.0,
-        h_threshold=5.0,  # m (nothing: no constraint)
+        h_threshold=nothing,  # m (nothing: no constraint)
         actual_time_limit=nothing,  # s (nothing: no constraint)
         N_thread=Threads.nthreads(),
         collector=Transducers.tcollect, will_plot=false, seed=2021,
@@ -21,7 +21,7 @@ function run_multiple_sim_training_cost(N=1;
     # rotor index ∈ {1, 2, 3, 4, 5, 6}
     # effectiveness ∈ [0, 1]
     _faults = 1:N |> Map(i -> [LoE(fault_time, rand(1:6), rand(1)[1])]) |> collect  # randomly sampled N faults
-    θs = [[0, 0, 0.0]]  # Control points of Bezier curve; constant position tracking
+    θs = [[0, 0, -9.0]]  # Control points of Bezier curve; constant position tracking
     θs_array = 1:N |> Map(i -> θs) |> collect
     run_multiple_sim(N,
                      manoeuvres,

--- a/src/run_multiple_sim.jl
+++ b/src/run_multiple_sim.jl
@@ -66,6 +66,8 @@ function run_multiple_sim(N::Int,
         will_plot::Bool, seed::Int,
     )
     println("Simulation case: $(N)")
+    println("manoeuvres: $(manoeuvres)")
+    println("methods: $(methods)")
     if collector == tcollect
         println("Parallel computing...")
         will_plot == true ? error("plotting figures not supported in tcollect") : nothing


### PR DESCRIPTION
Resolves #46.

1. (초기조건 고정) 현재는 `:debug` 기동을 취함 (이는, [0, 0, -10] 위치에서 호버링 상태로 시작함을 의미)
2. (말기조건 고정 및 궤적 파라미터 고정) Bezier curve 의 control points = [[0, 0, -9]] (desired position p_des(t) = constant 인 셈)
    - 너무 먼 값 (예: [[0, 0, 0]]) 을 잡으면 제어입력의 오버슛이 커서 시뮬레이션 시간이 지나치게 길어짐
3. (고장) 6개의 로터 중 랜덤하게 1개의 로터가 고장나는 상황을 고려하며, 이때 effectiveness in [0, 1].

### Notes
- 편의를 위해 `run_multiple_sim` 처음에 시뮬레이션할 기동 및 기법을 출력하게 함
- 100개의 시나리오에 대해 시뮬레이션을 돌렸을 때, 특별한 오류 없이 돌아감을 확인