### PR TITLE
Update traj data generation code

### DIFF
--- a/main/run_multiple_sim_training_cost.jl
+++ b/main/run_multiple_sim_training_cost.jl
@@ -8,7 +8,7 @@ using Test
 This is for the training of cost function.
 """
 function run_multiple_sim_training_cost(N=1;
-        manoeuvres=[:hovering],
+        manoeuvres=[:debug],
         methods=[:adaptive],
         t0=0.0, tf=20.0,
         h_threshold=nothing,  # m (nothing: no constraint)

--- a/main/run_multiple_sim_training_cost.jl
+++ b/main/run_multiple_sim_training_cost.jl
@@ -8,7 +8,7 @@ using Test
 This is for the training of cost function.
 """
 function run_multiple_sim_training_cost(N=1;
-        manoeuvres=[:debug],
+        manoeuvres=[:hovering],
         methods=[:adaptive],
         t0=0.0, tf=20.0,
         h_threshold=nothing,  # m (nothing: no constraint)
@@ -21,8 +21,11 @@ function run_multiple_sim_training_cost(N=1;
     # rotor index ∈ {1, 2, 3, 4, 5, 6}
     # effectiveness ∈ [0, 1]
     _faults = 1:N |> Map(i -> [LoE(fault_time, rand(1:6), rand(1)[1])]) |> collect  # randomly sampled N faults
-    θs = [[0, 0, -9.0]]  # Control points of Bezier curve; constant position tracking
-    θs_array = 1:N |> Map(i -> θs) |> collect
+    # for trajectory parameters (terminal position constraint)
+    multicopter = LeeHexacopter()  # dummy
+    min_nt, max_nt = FTCTests.distribution_info(:hovering)
+    # θs = [[0, 0, -10.0]]  # Control points of Bezier curve; constant position tracking
+    θs_array = 1:N |> Map(i -> [FTCTests.sample(multicopter, min_nt, max_nt)[1]]) |> collect  # sample(...)[1] corresponds to the position vector
     run_multiple_sim(N,
                      manoeuvres,
                      methods,

--- a/main/run_multiple_sim_training_cost.jl
+++ b/main/run_multiple_sim_training_cost.jl
@@ -24,7 +24,7 @@ function run_multiple_sim_training_cost(N=1;
     # for trajectory parameters (terminal position constraint)
     multicopter = LeeHexacopter()  # dummy
     min_nt, max_nt = FTCTests.distribution_info(:hovering)
-    # θs = [[0, 0, -10.0]]  # Control points of Bezier curve; constant position tracking
+    # Control points of Bezier curve; randomly generated constant position tracking
     θs_array = 1:N |> Map(i -> [FTCTests.sample(multicopter, min_nt, max_nt)[1]]) |> collect  # sample(...)[1] corresponds to the position vector
     run_multiple_sim(N,
                      manoeuvres,

--- a/main/train_cost.jl
+++ b/main/train_cost.jl
@@ -105,9 +105,10 @@ function main(epochs; dir_log="data/debug/adaptive", seed=2021)
             θ=3,
            )  # dimensions
     n = sum(n_nt)  # total dim (feature dimension)
-    n_h = 256  # hidden layer nodes
+    n_h = 128  # hidden layer nodes
     Ĵ = Chain(
               Dense(n, n_h, leakyrelu),
+              Dense(n_h, n_h, leakyrelu),
               Dense(n_h, 1, leakyrelu),
              )
     data_train, data_test = partitionTrainTest(data, 0.9)  # 90:10

--- a/main/train_cost.jl
+++ b/main/train_cost.jl
@@ -25,7 +25,13 @@ function preprocess(file_path::String; cf=PositionAngularVelocityCostFunctional(
         jld2 = JLD2.load(file_path)
         @unpack df, traj_des, faults = jld2
         @assert length(faults) == 1  # currently, only single fault is considered
+        # desired trajectory parameter
+        _θ = vcat(traj_des.θ...)  # concatenated control points
+        # actuator fault (effectiveness)
         λ = faults_to_effectiveness(faults)
+        # initial condition
+        x0 = df.sol[1].plant.state
+        # cost
         ts = df.time
         poss = df.sol |> Map(datum -> datum.plant.state.p) |> collect
         poss_des = ts |> Map(traj_des) |> collect
@@ -35,7 +41,7 @@ function preprocess(file_path::String; cf=PositionAngularVelocityCostFunctional(
         end
         e_ωs = ts |> Map(t -> zeros(3)) |> collect
         J = cost(cf, ts, e_ps, e_ωs)
-        return (; λ=λ, J=J)
+        return (; x0=x0, λ=λ, _θ=_θ, J=J)
     else
         if verbose
             @warn("ignored; the file's extension is not .jld2")
@@ -53,14 +59,13 @@ end
 function training_test(Ĵ, data_train, data_test, epochs)
     _data_train = make_a_trainable(data_train)
     _data_test = make_a_trainable(data_test)
-    loss(d) = Flux.Losses.mse(Ĵ(d.λ), d.J)
+    loss(d) = Flux.Losses.mse(Ĵ(d.feature), d.J)
     opt = ADAM(1e-3)
     ps = Flux.params(Ĵ)
-    dataloader = DataLoader(_data_train; batchsize=16, shuffle=true, partial=false)
+    dataloader = DataLoader(_data_train; batchsize=32, shuffle=true, partial=false)
     println("Training $(epochs) epoch...")
     for epoch in 0:epochs
         println("epoch: $(epoch)/$(epochs)")
-        println("train loss: $(loss(_data_train)), test loss: $(loss(_data_test))")
         if epoch != 0
             for d in dataloader
                 train_loss, back = Flux.Zygote.pullback(() -> loss(d), ps)
@@ -68,33 +73,43 @@ function training_test(Ĵ, data_train, data_test, epochs)
                 Flux.update!(opt, ps, gs)
             end
         end
+        println("train loss: $(loss(_data_train)), test loss: $(loss(_data_test))")
     end
 end
 
 function make_a_trainable(data)
-    λs = data |> Map(datum -> datum.λ) |> collect
+    # feature
+    features = data |> Map(datum -> vcat(
+                                         # datum.x0,
+                                         datum.λ,
+                                         datum._θ,
+                                        )) |> collect
+    # output
     Js = data |> Map(datum -> datum.J) |> collect
     _data = (;
-             λ = hcat(λs...),
+             feature = hcat(features...),
              J = hcat(Js...),
             )  # for Flux
 end
 
 
-function main(; dir_log="data/debug/adaptive")
+function main(epochs; dir_log="data/debug/adaptive", seed=2021)
+    Random.seed!(seed)
     # load data
     file_paths = readdir(dir_log; join=true)
-    data = preprocess(file_paths; verbose=false)
+    @time data = preprocess(file_paths; verbose=false)
     # construct approximator
-    n_λ = 6
-    n = n_λ  # total dim
-    n_h = 64  # hidden layer nodes
+    n_nt = (;
+            # x=18,
+            λ=6,
+            θ=3,
+           )  # dimensions
+    n = sum(n_nt)  # total dim (feature dimension)
+    n_h = 256  # hidden layer nodes
     Ĵ = Chain(
               Dense(n, n_h, leakyrelu),
-              Dense(n_h, n_h, leakyrelu),
               Dense(n_h, 1, leakyrelu),
              )
     data_train, data_test = partitionTrainTest(data, 0.9)  # 90:10
-    epochs = 30
     training_test(Ĵ, data_train, data_test, epochs)
 end


### PR DESCRIPTION
#54 (partially resolved)

Merge it after #53 is reviewed and merged.

## 실험

### 분석
- #53 와 비교했을 때, test loss 의 오더가 상승함
    - 데이터 개수를 늘렸을 때 이것이 개선될지는 확인이 필요
- cost 값이 대충 0~2 정도 분포했음. 즉, 최대값 대비 평균 2.5% 정도의 오차를 보임 -> 데이터 개수를 500개로 늘리니 0.5%정도의 오차로 줄어듦

### 결과 1
- 초기조건이 고정되고, 궤적 파라미터 (상수 궤적) 를 랜덤하게 변경한 100개의 데이터로 학습함
```julia
epoch: 490/500
train loss: 0.04503805318259698, test loss: 0.04810623734922672
epoch: 491/500
train loss: 0.04430858432891502, test loss: 0.047071281567201056
epoch: 492/500
train loss: 0.045794739081250216, test loss: 0.04412293497425684
epoch: 493/500
train loss: 0.044308797635761635, test loss: 0.04541345746295398
epoch: 494/500
train loss: 0.04509754495954448, test loss: 0.052094933080495086
epoch: 495/500
train loss: 0.0444691486654015, test loss: 0.05142818097239678
epoch: 496/500
train loss: 0.0445010070274344, test loss: 0.0476656591470513
epoch: 497/500
train loss: 0.04435291862398784, test loss: 0.04621449524361766
epoch: 498/500
train loss: 0.04404660949320234, test loss: 0.04525638869335364
epoch: 499/500
train loss: 0.04405194051662392, test loss: 0.046091424930600464
epoch: 500/500
train loss: 0.04400790758492827, test loss: 0.04486687605259744
```
### 결과 2
- 초기조건이 고정되고, 궤적 파라미터 (상수 궤적) 를 랜덤하게 변경한 500개의 데이터로 학습함. epoch를 1000개로 늘림
```julia
epoch: 990/1000
train loss: 0.006585062535652302, test loss: 0.009129077215332525
epoch: 991/1000
train loss: 0.00590244877598379, test loss: 0.009625629937753262
epoch: 992/1000
train loss: 0.0072928134854061575, test loss: 0.011373839406195225
epoch: 993/1000
train loss: 0.006306521163276164, test loss: 0.010751361105481338
epoch: 994/1000
train loss: 0.017537169693366897, test loss: 0.02009221965855168
epoch: 995/1000
train loss: 0.0061754190715973874, test loss: 0.008788245272527154
epoch: 996/1000
train loss: 0.006484239708325825, test loss: 0.009061958436653713
epoch: 997/1000
train loss: 0.00666492314316285, test loss: 0.010788371089625439
epoch: 998/1000
train loss: 0.006822148854414358, test loss: 0.009971723669883005
epoch: 999/1000
train loss: 0.008385256711416616, test loss: 0.012257413496356314
epoch: 1000/1000
train loss: 0.006311904495964465, test loss: 0.009735567733803761

```

## Notes
### 네트워크 구조
- single hidden layer feedforward neural network
```julia
    n_h = 256  # hidden layer nodes
    Ĵ = Chain(
              Dense(n, n_h, leakyrelu),
              Dense(n_h, 1, leakyrelu),
             )
```

### 데이터 읽고 쓰기
- preprocessing 과정에서 시간이 꽤 소요됨 (100개: 약 10초 내외, 500개: 약 40초 내외). 이를 개선하려면, preprocessing 된 데이터를 따로 저장해두고 불러와서 쓰는게 좋을듯
### 하이퍼 파라미터
- 최고의 성능을 보이기 위해서는 약간의 튜닝이 필요했음 (네트워크 구조 등)
- mini-batch size 가 너무 작으면 오버피팅이 발생함. 32 이상에서 해당 현상이 완화됨을 확인함
### 초기조건도 cost approximator 의 변수에 추가한다면?
- 현재는 상태변수 차원이 18차원. quaternion 변환을 한다면 13차원까지 줄일 수 있을 것으로 보임 (단위 쿼터니언이므로 대충 12차원).
    - 간단하게 로컬에서 18차원 상태변수를 추가했을 때, test loss 값이 꽤 큰 것을 확인함 (1정도; 그러나 최대 cost 도 더 컸음). 이는 다른 PR 을 통해 개선 또는 기능 추가해야할 것으로 생각됨