### PR TITLE
Fix iss48

### DIFF
--- a/test/run_sim.jl
+++ b/test/run_sim.jl
@@ -1,4 +1,5 @@
 using Test
+using FTCTests
 
 
 @testset "run_sim" begin

--- a/test/run_sim.jl
+++ b/test/run_sim.jl
@@ -3,6 +3,7 @@ using Test
 
 @testset "run_sim" begin
     dir_log = "__data__"
+    dir_figure = "__figures__"
     case_number = 1
     mkpath(dir_log)
     method = :adaptive
@@ -16,5 +17,5 @@ using Test
     θs = [[0, 0, 0.0]]  # constant position tracking
     traj_des = Bezier(θs, t0, tf)
     run_sim(method, args_multicopter, multicopter, fault, fdi, traj_des, dir_log, case_number;
-            t0=t0, tf=tf, savestep=0.01, will_plot=true)
+            t0=t0, tf=tf, savestep=0.01, dir_figure=dir_figure)
 end


### PR DESCRIPTION
Resolves #48.

궤적 데이터는 `./data` 에, 그림 데이터는 `./figures` 에 저장하게끔 함.

Note: 병렬 연산 시 Plots 의 기본 backend 인 GR 은 concurrency issue 가 있는 것으로 보임