### PR TITLE
Add init cond for training cost

### DIFF
--- a/main/run_multiple_sim_training_cost.jl
+++ b/main/run_multiple_sim_training_cost.jl
@@ -8,7 +8,7 @@ using Test
 This is for the training of cost function.
 """
 function run_multiple_sim_training_cost(N=1;
-        manoeuvres=[:hovering],
+        manoeuvres=[:debug],
         methods=[:adaptive],
         t0=0.0, tf=20.0,
         h_threshold=nothing,  # m (nothing: no constraint)

--- a/main/run_multiple_sim_training_cost.jl
+++ b/main/run_multiple_sim_training_cost.jl
@@ -8,7 +8,7 @@ using Test
 This is for the training of cost function.
 """
 function run_multiple_sim_training_cost(N=1;
-        manoeuvres=[:debug],
+        manoeuvres=[:hovering],
         methods=[:adaptive],
         t0=0.0, tf=20.0,
         h_threshold=nothing,  # m (nothing: no constraint)

--- a/main/train_cost.jl
+++ b/main/train_cost.jl
@@ -26,7 +26,6 @@ function preprocess(file_path::String; cf=PositionAngularVelocityCostFunctional(
             df = jld2["df"]
             traj_des = jld2["traj_des"]
             faults = jld2["faults"]
-            # @unpack df, traj_des, faults = jld2
             @assert length(faults) == 1  # currently, only single fault is considered
             # desired trajectory parameter
             _θ = vcat(traj_des.θ...)  # concatenated control points

--- a/main/train_cost.jl
+++ b/main/train_cost.jl
@@ -105,10 +105,9 @@ function main(epochs; dir_log="data/debug/adaptive", seed=2021)
             θ=3,
            )  # dimensions
     n = sum(n_nt)  # total dim (feature dimension)
-    n_h = 128  # hidden layer nodes
+    n_h = 256  # hidden layer nodes
     Ĵ = Chain(
               Dense(n, n_h, leakyrelu),
-              Dense(n_h, n_h, leakyrelu),
               Dense(n_h, 1, leakyrelu),
              )
     data_train, data_test = partitionTrainTest(data, 0.9)  # 90:10

--- a/main/train_cost.jl
+++ b/main/train_cost.jl
@@ -86,7 +86,6 @@ function make_a_trainable(data)
                                         )) |> collect
     # output
     Js = data |> Map(datum -> datum.J) |> collect
-    @show Js |> maximum
     _data = (;
              feature = hcat(features...),
              J = hcat(Js...),
@@ -106,7 +105,7 @@ function main(epochs; dir_log="data/hovering/adaptive", seed=2021)
             θ=3,
            )  # dimensions
     n = sum(n_nt)  # total dim (feature dimension)
-    n_h = 128  # hidden layer nodes
+    n_h = 256  # hidden layer nodes
     Ĵ = Chain(
               Dense(n, n_h, leakyrelu),
               Dense(n_h, n_h, leakyrelu),

--- a/main/train_cost.jl
+++ b/main/train_cost.jl
@@ -80,12 +80,13 @@ end
 function make_a_trainable(data)
     # feature
     features = data |> Map(datum -> vcat(
-                                         # datum.x0,
+                                         datum.x0,
                                          datum.λ,
                                          datum._θ,
                                         )) |> collect
     # output
     Js = data |> Map(datum -> datum.J) |> collect
+    @show Js |> maximum
     _data = (;
              feature = hcat(features...),
              J = hcat(Js...),
@@ -93,14 +94,14 @@ function make_a_trainable(data)
 end
 
 
-function main(epochs; dir_log="data/debug/adaptive", seed=2021)
+function main(epochs; dir_log="data/hovering/adaptive", seed=2021)
     Random.seed!(seed)
     # load data
     file_paths = readdir(dir_log; join=true)
     @time data = preprocess(file_paths; verbose=false)
     # construct approximator
     n_nt = (;
-            # x=18,
+            x=18,
             λ=6,
             θ=3,
            )  # dimensions

--- a/main/train_cost.jl
+++ b/main/train_cost.jl
@@ -105,9 +105,10 @@ function main(epochs; dir_log="data/debug/adaptive", seed=2021)
             θ=3,
            )  # dimensions
     n = sum(n_nt)  # total dim (feature dimension)
-    n_h = 256  # hidden layer nodes
+    n_h = 128  # hidden layer nodes
     Ĵ = Chain(
               Dense(n, n_h, leakyrelu),
+              Dense(n_h, n_h, leakyrelu),
               Dense(n_h, 1, leakyrelu),
              )
     data_train, data_test = partitionTrainTest(data, 0.9)  # 90:10


### PR DESCRIPTION
Resolves #54.

training, test 각 집단에서 cost 의 최대값은 약 8, 4였음.
테스트 오차로부터, 500개의 데이터를 이용 시 평균 5% 정도의 오차가 나타남을 확인함
```julia
epoch: 990/1000
train loss: 0.001046324435322738, test loss: 0.27286239687375974
epoch: 991/1000
train loss: 0.0005235142947336805, test loss: 0.27874615888703913
epoch: 992/1000
train loss: 0.0004984139891853737, test loss: 0.2731008950697275
epoch: 993/1000
train loss: 0.00104262273868247, test loss: 0.27260488533589344
epoch: 994/1000
train loss: 0.0019057257426483261, test loss: 0.2818110231544317
epoch: 995/1000
train loss: 0.0007244294380044717, test loss: 0.27326609706830196
epoch: 996/1000
train loss: 0.0010500050382547404, test loss: 0.2759672378722521
epoch: 997/1000
train loss: 0.0006593412251548647, test loss: 0.2701378165143371
epoch: 998/1000
train loss: 0.0005065906958324352, test loss: 0.2776949684072853
epoch: 999/1000
train loss: 0.0003101717115486359, test loss: 0.27189290547653217
epoch: 1000/1000
train loss: 0.00016773476411603095, test loss: 0.276555138063298

```