### PR TITLE
Add main/compare_gramian.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["JinraeKim <kjl950403@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
+ControlSystems = "a6e380b2-a6ca-5380-bf3e-84a91bcd477e"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 FaultTolerantControl = "45299f66-0548-4da8-9567-4dae0facc19d"

--- a/main/compare_gramian.jl
+++ b/main/compare_gramian.jl
@@ -1,0 +1,40 @@
+using FTCTests
+using ControlSystems: ss, gram
+using LinearAlgebra
+
+
+function compute_empirical_gramian()
+	A = -Matrix(I, 4, 4)
+	B = [0.0 1.0 0.0 1.0]'
+	C = [0.0 0.0 1.0 1.0]
+
+	f(x, u, p, t) = A*x + B*u .+ p
+	g(x, u, p, t) = C*x
+
+	# System dimension
+	n = 4
+	m = 1
+	l = 1
+
+	x0 = [0.0, 0.0, 0.0, 0.0]
+	u0 = [0.0]
+
+	Wc = empirical_ctrl_gramian(f, [m, n, l]; dt=0.01, tf=1.0, pr=zeros(4, 1), xs=x0)
+	Wo = empirical_obsv_gramian(f, g, [m, n, l]; dt=0.01, tf=1.0, pr=zeros(4, 1), xs=x0, us=u0)
+	@show Wc Wo
+    nothing
+end
+
+function compute_gramian()
+	A = -Matrix(I, 4, 4)
+	B = [0.0 1.0 0.0 1.0]'
+	C = [0.0 0.0 1.0 1.0]
+    D = [0]
+
+    sys = ss(A, B, C, D)
+
+    Wc = gram(sys, :c)
+    Wo = gram(sys, :o)
+    @show Wc Wo
+    nothing
+end


### PR DESCRIPTION
Resolve #65 
선형시스템에 대해서 empirical gramian과 gramian의 값을 비교하기 위해 스크립트를 작성하였습니다. 
결과는 아래와 같습니다. 각 요소의 오차를 비교하면 약 6~7%정도인 것으로 보입니다.
값을 비교하는 방법에 대해서는 조금 더 분석이 필요할 것 같습니다.

### Results
```julia
julia> compute_empirical_gramian()
Wc = [0.0 0.0 0.0 0.0; 
0.0 0.4323240014844255 0.0 0.4323240014844255; 
0.0 0.0 0.0 0.0; 
0.0 0.4323240014844255 0.0 0.4323240014844255]
Wo = [0.0 0.0 0.0 0.0; 
0.0 0.0 0.0 0.0; 
0.0 0.0 0.4380259443429692 0.4380259443429692;
0.0 0.0 0.4380259443429692 0.4380259443429692]

julia> compute_gramian()
Wc = [0.0 0.0 0.0 0.0; 
0.0 0.5000000000000001 0.0 0.5; 
0.0 0.0 0.0 0.0; 
0.0 0.5 0.0 0.4999999999999999]
Wo = [0.0 0.0 0.0 0.0; 
0.0 0.0 0.0 0.0; 
0.0 0.0 0.5000000000000001 0.5000000000000001; 
0.0 0.0 0.5000000000000001 0.5000000000000001]
```