### PR TITLE
쿼드콥터 모델에 대해 reconfigurability 계산

### DIFF
--- a/main/compute_gram_f16_linear.jl
+++ b/main/compute_gram_f16_linear.jl
@@ -4,7 +4,16 @@ using LinearAlgebra
 using Plots
 
 
+"""
+# Refs
+[1] K. G. Vamvoudakis and F. L. Lewis, “Online actor-critic algorithm to solve the continuous-time infinite horizon optimal control problem,” Automatica, vol. 46, no. 5, pp. 878–888, 2010, doi: 10.1016/j.automatica.2010.02.018.
+
+# Notes
+- x = state vector, [v, alpha, q]^T
+- u = control input vector, [dele]
+"""
 function compute_minHSV(eff)
+    # F16 aircraft longitudinal linear system model [1]
     A = [-1.01887 0.90506 -0.00215;
     0.82225 -1.07741 -0.17555;
     0 0 -1]

--- a/main/compute_gram_f16_linear.jl
+++ b/main/compute_gram_f16_linear.jl
@@ -1,0 +1,47 @@
+using FTCTests
+const FTC = FaultTolerantControl
+using LinearAlgebra
+using Plots
+
+
+function compute_minHSV(eff)
+    A = [-1.01887 0.90506 -0.00215;
+    0.82225 -1.07741 -0.17555;
+    0 0 -1]
+    B = [0 0 1]'
+    C = Matrix(I, 3, 3)
+
+    f(x, u, p, t) = A*x + B*(eff * u)
+    g(x, u, p, t) = C*x
+
+	# System dimension
+	n = size(A)[1]
+	m = 1
+	l = size(C)[1]
+
+    # Initial settings
+    x0 = zeros(n,)
+    u0 = zeros(m,)
+    dt = 0.001
+    tf = 1.0
+    pr = zeros(3, 1)
+
+    Wc = empirical_gramian(f, g, m, n, l; opt=:c, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
+    Wo = empirical_gramian(f, g, m, n, l; opt=:o, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
+	minHSV = min_HSV(Wc, Wo)
+end
+
+function plotting()
+    lambda = range(0, 1, 20)
+    HSVs = []
+    for i = 1:length(lambda)
+        HSVs = push!(HSVs, compute_minHSV(collect(lambda)[i]))
+    end
+    plot(lambda,
+        HSVs,
+        xlabel = "Actuator effectiveness",
+        ylabel = "Minimum HSVs",
+        label = nothing,
+    )
+end
+nothing

--- a/main/compute_gram_quadcopter.jl
+++ b/main/compute_gram_quadcopter.jl
@@ -4,8 +4,21 @@ using LinearAlgebra
 using Plots
 
 
+"""
+# Refs
+[1] M. Tahavori and A. Hasan, “Fault recoverability for nonlinear systems with application to fault tolerant control of UAVs,” Aerosp. Sci. Technol., vol. 107, p. 106282, 2020, doi: 10.1016/j.ast.2020.106282.
+
+# Notes
+- x = state vector, [eta, omega, v, xi]^T
+    - eta = Euler angle vector, [phi, theta, psi]^T
+    - omega = angular rate vector, [p, q, r]^T
+    - v = velocity vector, [u, v, w]^T
+    - xi = position vector, [x, y, z]^T
+- u = control input vector, thrust vector, [omega_1, omega_2, omega_3, omega_4]^T
+- y = output vector, [eta, omega, xi]^T
+"""
 function compute_minHSV(lambda, num=1)
-    # Quadcopter state space model
+    # Quadcopter state space model [1]
     gc = 9.81
     m = 0.65
     l = 0.023

--- a/main/compute_gram_quadcopter.jl
+++ b/main/compute_gram_quadcopter.jl
@@ -1,0 +1,113 @@
+using FTCTests
+const FTC = FaultTolerantControl
+using LinearAlgebra
+using Plots
+
+
+function compute_minHSV(lambda, num=1)
+    # Quadcopter state space model
+    gc = 9.81
+    m = 0.65
+    l = 0.023
+    k = 31.1e-5
+    b = 7.5e-7
+    J = Diagonal([7.5e-3, 7.4e-3, 1.3e-2])
+    Jinv = inv(J)
+    A = [zeros(3, 3) Matrix(I, 3, 3) zeros(3, 3) zeros(3, 3);
+    zeros(3, 3) zeros(3, 3) zeros(3, 3) zeros(3, 3);
+    zeros(3, 3) zeros(3, 3) zeros(3, 3) zeros(3, 3);
+    zeros(3, 3) zeros(3, 3) Matrix(I, 3, 3) zeros(3, 3)]
+    B = zeros(12, 4)
+    for i = 1:12
+        for j = 1:4
+            if i == 5
+                if j == 1
+                    B[i, j] = -l*k/J[2, 2]
+                elseif j == 3
+                    B[i, j] = l*k/J[2, 2]
+                end
+            elseif i == 4
+                if j == 2
+                    B[i, j] = -l*k/J[1, 1]
+                elseif j == 4
+                    B[i, j] = l*k/J[1, 1]
+                end
+            elseif i == 6
+                if j == 1 || j == 3
+                    B[i, j] = -b/J[3, 3]
+                elseif j == 2 || j == 4
+                    B[i, j] = b/J[3, 3]
+                end
+            elseif i == 9
+                if j == 1 || j == 2 || j == 3 || j == 4
+                    B[i, j] = k/m
+                end
+            else
+                B[i, j] = 0
+            end
+        end
+    end
+    C = [Matrix(I, 3, 3) zeros(3, 3) zeros(3, 3) zeros(3, 3);
+    zeros(3, 3) Matrix(I, 3, 3) zeros(3, 3) zeros(3, 3);
+    zeros(3, 3) zeros(3, 3) zeros(3, 3) Matrix(I, 3, 3)]
+
+    u_ss = sqrt(m*gc/4/k) * ones(4,)
+    T(x) = [-sin(x[2]) 0 1;
+            cos(x[2])*sin(x[3]) cos(x[3]) 0;
+            cos(x[2])*cos(x[3]) -sin(x[3]) 0]
+    R(x) = [cos(x[2])*cos(x[3]) sin(x[3])*sin(x[2]) -sin(x[2]);
+            cos(x[3])*sin(x[2])*sin(x[1])-sin(x[3])*cos(x[1]) sin(x[3])*sin(x[2])*sin(x[1])+cos(x[3])*cos(x[1]) cos(x[2])*sin(x[1]);
+            cos(x[3])*sin(x[2])*cos(x[1])-sin(x[3])*sin(x[1]) sin(x[3])*sin(x[2])*cos(x[1])+cos(x[3])*sin(x[1]) cos(x[2])*cos(x[1])]
+    F(x) = vec([
+        T(x) * x[4:6]
+        Jinv * cross(-x[4:6], J * x[4:6])
+        -cross(x[4:6], x[7:9]) + gc * R(x)' * [0; 0; 1]
+        R(x) * x[7:9]
+    ])
+
+    if num == 1
+        eff = Diagonal([lambda, 1, 1, 1])
+    elseif num == 2
+        eff = Diagonal([1, lambda, 1, 1])
+    elseif num == 3
+        eff = Diagonal([1, 1, lambda, 1])
+    elseif num == 4
+        eff = Diagonal([1, 1, 1, lambda])
+    else
+        error("Choose fauly actuator number")
+    end
+
+    f(x, u, p, t) = A*x + F(x) + B*(eff * u + u_ss).^2
+    g(x, u, p, t) = C*x
+
+	# System dimension
+	n = size(A)[1]
+	m = size(B)[2]
+	l = size(C)[1]
+
+    # Initial settings
+    x0 = zeros(n,)
+    u0 = zeros(m,)
+    dt = 0.001
+    tf = 1.0
+    pr = zeros(4, 1)
+
+    Wc = FTC.empirical_gramian(f, g, m, n, l; opt=:c, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
+    Wo = FTC.empirical_gramian(f, g, m, n, l; opt=:o, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
+	minHSV = FTC.min_HSV(Wc, Wo)
+end
+
+function plotting()
+    lambda = range(0, 1, 20)
+    HSVs = []
+    for i = 1:length(lambda)
+        HSVs = push!(HSVs, compute_minHSV(collect(lambda)[i], 2))
+    end
+    plot(lambda,
+        HSVs,
+        xlabel = "Actuator effectiveness",
+        ylabel = "Minimum HSVs",
+        label = nothing,
+    )
+end
+nothing


### PR DESCRIPTION
Resolve #66 
비선형 쿼드콥터 시스템에 대해 reconfigurability를 계산하는 스크립트를 작성함.
(220204 세미나 자료와 다르게 각 로터별 고장에 대해서 다음과 같은 그래프가 모두 동일하게 나옴,
아마도 이전에 실수가 있었던 것 같습니다..)
추가로, F16 aircraft 선형시스템에 대한 계산 스크립트도 함께 작성하였습니다.

- Results
![image](https://user-images.githubusercontent.com/32696021/152786664-d5bb5a89-720f-47dc-a4d7-cf9b3aedeba9.png)
