### PR TITLE
Fix example model to compute gramian of quadcopter

### DIFF
--- a/main/compute_gram_quadcopter.jl
+++ b/main/compute_gram_quadcopter.jl
@@ -76,7 +76,7 @@ function compute_minHSV_example(lambda, num::Int; dt=0.01, tf=1.0)
             0 sec(x[2])*sin(x[1]) cos(x[1])*sec(x[2])]
     R(x) = [cos(x[2])*cos(x[3]) sin(x[1])*sin(x[2])*cos(x[3])-cos(x[1])*sin(x[3]) cos(x[1])*sin(x[2])*cos(x[3])+sin(x[1])*sin(x[3]);
             cos(x[2])*sin(x[3]) sin(x[1])*sin(x[2])*sin(x[3])-cos(x[1])*cos(x[3]) cos(x[1])*sin(x[2])*sin(x[3])-sin(x[1])*cos(x[3]);
-            -sin(x[2]) sin(x[1])*cos(x[2]) cos(x[1])*cos(x[2])]'
+            -sin(x[2]) sin(x[1])*cos(x[2]) cos(x[1])*cos(x[2])]
     F(x) = vec([
         T(x) * x[4:6]
         Jinv * cross(-x[4:6], J * x[4:6])
@@ -92,13 +92,13 @@ function compute_minHSV_example(lambda, num::Int; dt=0.01, tf=1.0)
 	l = size(C)[1]
 
     # Initial settings
-    x0 = zeros(n,)
-    u0 = zeros(m,)
+    x0 = zeros(n)
+    u0 = zeros(m)
     pr = zeros(4, 1)
 
     Wc = FTC.empirical_gramian(f, g, m, n, l; opt=:c, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
     Wo = FTC.empirical_gramian(f, g, m, n, l; opt=:o, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
-	# minHSV = FTC.min_HSV(Wc, Wo)
+    # minHSV = FTC.min_HSV(Wc, Wo)
     eigvals_Wc = Wc |> LinearAlgebra.eigvals |> minimum |> sqrt
 end
 
@@ -153,17 +153,17 @@ function compute_minHSV_squared(lambda, num::Int; dt=0.01, tf=1.0)
 
     Wc = FTC.empirical_gramian(f, g, m, n, l; opt=:c, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
     Wo = FTC.empirical_gramian(f, g, m, n, l; opt=:o, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
-    _eigvals_WcWo = Wc*Wo |> LinearAlgebra.eigvals
-    eigvals_WcWo = []
-    for eigval in _eigvals_WcWo
+    _eigvals_Wc = Wc |> LinearAlgebra.eigvals
+    eigvals_Wc = []
+    for eigval in _eigvals_Wc
         if abs(imag(eigval)) < 1e-6
-            push!(eigvals_WcWo, real(eigval))
+            push!(eigvals_Wc, real(eigval))
         else
             error("Too large imaginary part")
         end
     end
-    min_HSV_squared = eigvals_WcWo |> minimum  # not min_HSV
-	# minHSV = FTC.min_HSV(Wc, Wo)
+    min_HSV_squared = eigvals_Wc |> minimum  # not min_HSV
+    # minHSV = FTC.min_HSV(Wc, Wo)
 end
 
 function plotting(rotor_idx)

--- a/main/compute_gram_quadcopter.jl
+++ b/main/compute_gram_quadcopter.jl
@@ -123,7 +123,7 @@ function test_model()
 end
 
 
-function compute_minHSV_squared(lambda, num::Int; dt=0.01, tf=1.0)
+function compute_minHSV_Islam(lambda, num::Int; dt=0.01, tf=1.0)
     @assert lambda >= 0.0 && lambda <= 1.0
     Λ = diagm(ones(4))
     Λ[num, num] = lambda
@@ -172,7 +172,7 @@ function plotting(rotor_idx)
     HSVs = []
     for i = 1:length(lambda)
         # HSVs = push!(HSVs, compute_minHSV_example(lambda[i], rotor_idx))
-        HSVs = push!(HSVs, compute_minHSV_squared(lambda[i], rotor_idx))
+        HSVs = push!(HSVs, compute_minHSV_Islam(lambda[i], rotor_idx))
     end
     return plot(lambda,
                 HSVs,

--- a/main/compute_gram_quadcopter.jl
+++ b/main/compute_gram_quadcopter.jl
@@ -148,11 +148,12 @@ function compute_minHSV_squared(lambda, num::Int; dt=0.01, tf=1.0)
     quat = dcm_to_quat(DCM(X0.R))
     _quat = [quat.q0, quat.q1, quat.q2, quat.q3]
     x0 = [X0.p..., X0.v..., _quat..., X0.ω...]
-    u0 = (multicopter.m * multicopter.g / multicopter.kf) / 4 * ones(4)
+    # u0 = (multicopter.m * multicopter.g / multicopter.kf) / 4 * ones(4)
+    u0 = zeros(4)
     pr = zeros(4, 1)
 
-    Wc = FTC.empirical_gramian(f, g, m, n, l; opt=:c, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
-    Wo = FTC.empirical_gramian(f, g, m, n, l; opt=:o, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
+    Wc = FTC.empirical_gramian(f, g, m, n, l; opt=:c, dt=dt, tf=tf, pr=pr, xs=x0, us=u0, xm=1.0, um=10000.0)
+    Wo = FTC.empirical_gramian(f, g, m, n, l; opt=:o, dt=dt, tf=tf, pr=pr, xs=x0, us=u0, xm=1.0, um=10000.0)
     _eigvals_Wc = Wc |> LinearAlgebra.eigvals
     eigvals_Wc = []
     for eigval in _eigvals_Wc
@@ -170,8 +171,8 @@ function plotting(rotor_idx)
     lambda = 0:0.10:1 |> collect
     HSVs = []
     for i = 1:length(lambda)
-        HSVs = push!(HSVs, compute_minHSV_example(lambda[i], rotor_idx))
-        # HSVs = push!(HSVs, compute_minHSV_squared(lambda[i], rotor_idx))
+        # HSVs = push!(HSVs, compute_minHSV_example(lambda[i], rotor_idx))
+        HSVs = push!(HSVs, compute_minHSV_squared(lambda[i], rotor_idx))
     end
     return plot(lambda,
                 HSVs,

--- a/main/compute_gram_quadcopter.jl
+++ b/main/compute_gram_quadcopter.jl
@@ -7,6 +7,102 @@ using Debugger
 using ReferenceFrameRotations
 
 
+"""
+# Refs
+[1] M. Tahavori and A. Hasan, “Fault recoverability for nonlinear systems with application to fault tolerant control of UAVs,” Aerosp. Sci. Technol., vol. 107, p. 106282, 2020, doi: 10.1016/j.ast.2020.106282.
+
+# Notes
+- x = state vector, [eta, omega, v, xi]^T
+    - eta = Euler angle vector, [phi, theta, psi]^T
+    - omega = angular rate vector, [p, q, r]^T
+    - v = velocity vector, [u, v, w]^T
+    - xi = position vector, [x, y, z]^T
+- u = control input vector, thrust vector, [omega_1, omega_2, omega_3, omega_4]^T
+- y = output vector, [eta, omega, xi]^T
+"""
+function compute_minHSV_example(lambda, num::Int; dt=0.01, tf=1.0)
+    @assert lambda >= 0.0 && lambda <= 1.0
+    Λ = diagm(ones(4))
+    Λ[num, num] = lambda
+    # @show Λ
+    # Quadcopter state space model [1]
+    gc = 9.81
+    m = 0.65
+    l = 0.023
+    k = 31.1e-5
+    b = 7.5e-7
+    J = Diagonal([7.5e-3, 7.4e-3, 1.3e-2])
+    Jinv = inv(J)
+    A = [zeros(3, 3) Matrix(I, 3, 3) zeros(3, 3) zeros(3, 3);
+    zeros(3, 3) zeros(3, 3) zeros(3, 3) zeros(3, 3);
+    zeros(3, 3) zeros(3, 3) zeros(3, 3) zeros(3, 3);
+    zeros(3, 3) zeros(3, 3) Matrix(I, 3, 3) zeros(3, 3)]
+    B = zeros(12, 4)
+    for i = 1:12
+        for j = 1:4
+            if i == 5
+                if j == 1
+                    B[i, j] = -l*k/J[2, 2]
+                elseif j == 3
+                    B[i, j] = l*k/J[2, 2]
+                end
+            elseif i == 4
+                if j == 2
+                    B[i, j] = -l*k/J[1, 1]
+                elseif j == 4
+                    B[i, j] = l*k/J[1, 1]
+                end
+            elseif i == 6
+                if j == 1 || j == 3
+                    B[i, j] = -b/J[3, 3]
+                elseif j == 2 || j == 4
+                    B[i, j] = b/J[3, 3]
+                end
+            elseif i == 9
+                if j == 1 || j == 2 || j == 3 || j == 4
+                    B[i, j] = k/m
+                end
+            else
+                B[i, j] = 0
+            end
+        end
+    end
+    C = [Matrix(I, 3, 3) zeros(3, 3) zeros(3, 3) zeros(3, 3);
+    zeros(3, 3) Matrix(I, 3, 3) zeros(3, 3) zeros(3, 3);
+    zeros(3, 3) zeros(3, 3) zeros(3, 3) Matrix(I, 3, 3)]
+
+    T(x) = [1 sin(x[1])*tan(x[2]) cos(x[1])*tan(x[2]);
+            0 cos(x[1]) -sin(x[1]);
+            0 sec(x[2])*sin(x[1]) cos(x[1])*sec(x[2])]
+    R(x) = [cos(x[2])*cos(x[3]) sin(x[1])*sin(x[2])*cos(x[3])-cos(x[1])*sin(x[3]) cos(x[1])*sin(x[2])*cos(x[3])+sin(x[1])*sin(x[3]);
+            cos(x[2])*sin(x[3]) sin(x[1])*sin(x[2])*sin(x[3])-cos(x[1])*cos(x[3]) cos(x[1])*sin(x[2])*sin(x[3])-sin(x[1])*cos(x[3]);
+            -sin(x[2]) sin(x[1])*cos(x[2]) cos(x[1])*cos(x[2])]'
+    F(x) = vec([
+        T(x) * x[4:6]
+        Jinv * cross(-x[4:6], J * x[4:6])
+        -cross(x[4:6], x[7:9]) + gc * R(x)' * [0; 0; 1]
+        R(x) * x[7:9]
+    ])
+
+    f(x, u, p, t) = A*x + F(x) + B*(Λ*u).^2
+    g(x, u, p, t) = C*x
+
+	# System dimension
+	n, m = size(B)
+	l = size(C)[1]
+
+    # Initial settings
+    x0 = zeros(n,)
+    u0 = zeros(m,)
+    pr = zeros(4, 1)
+
+    Wc = FTC.empirical_gramian(f, g, m, n, l; opt=:c, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
+    Wo = FTC.empirical_gramian(f, g, m, n, l; opt=:o, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
+	# minHSV = FTC.min_HSV(Wc, Wo)
+    eigvals_Wc = Wc |> LinearAlgebra.eigvals |> minimum |> sqrt
+end
+
+
 function Dynamics!(multicopter::IslamQuadcopter)
     @unpack B = multicopter
     function dynamics!(dx, x, param, t; u, Λ)
@@ -27,114 +123,7 @@ function test_model()
 end
 
 
-# """
-# # Refs
-# [1] M. Tahavori and A. Hasan, “Fault recoverability for nonlinear systems with application to fault tolerant control of UAVs,” Aerosp. Sci. Technol., vol. 107, p. 106282, 2020, doi: 10.1016/j.ast.2020.106282.
-
-# # Notes
-# - x = state vector, [eta, omega, v, xi]^T
-#     - eta = Euler angle vector, [phi, theta, psi]^T
-#     - omega = angular rate vector, [p, q, r]^T
-#     - v = velocity vector, [u, v, w]^T
-#     - xi = position vector, [x, y, z]^T
-# - u = control input vector, thrust vector, [omega_1, omega_2, omega_3, omega_4]^T
-# - y = output vector, [eta, omega, xi]^T
-# """
-# function compute_minHSV_deprecated(lambda, num=1)
-#     # Quadcopter state space model [1]
-#     gc = 9.81
-#     m = 0.65
-#     l = 0.023
-#     k = 31.1e-5
-#     b = 7.5e-7
-#     J = Diagonal([7.5e-3, 7.4e-3, 1.3e-2])
-#     Jinv = inv(J)
-#     A = [zeros(3, 3) Matrix(I, 3, 3) zeros(3, 3) zeros(3, 3);
-#     zeros(3, 3) zeros(3, 3) zeros(3, 3) zeros(3, 3);
-#     zeros(3, 3) zeros(3, 3) zeros(3, 3) zeros(3, 3);
-#     zeros(3, 3) zeros(3, 3) Matrix(I, 3, 3) zeros(3, 3)]
-#     B = zeros(12, 4)
-#     for i = 1:12
-#         for j = 1:4
-#             if i == 5
-#                 if j == 1
-#                     B[i, j] = -l*k/J[2, 2]
-#                 elseif j == 3
-#                     B[i, j] = l*k/J[2, 2]
-#                 end
-#             elseif i == 4
-#                 if j == 2
-#                     B[i, j] = -l*k/J[1, 1]
-#                 elseif j == 4
-#                     B[i, j] = l*k/J[1, 1]
-#                 end
-#             elseif i == 6
-#                 if j == 1 || j == 3
-#                     B[i, j] = -b/J[3, 3]
-#                 elseif j == 2 || j == 4
-#                     B[i, j] = b/J[3, 3]
-#                 end
-#             elseif i == 9
-#                 if j == 1 || j == 2 || j == 3 || j == 4
-#                     B[i, j] = k/m
-#                 end
-#             else
-#                 B[i, j] = 0
-#             end
-#         end
-#     end
-#     C = [Matrix(I, 3, 3) zeros(3, 3) zeros(3, 3) zeros(3, 3);
-#     zeros(3, 3) Matrix(I, 3, 3) zeros(3, 3) zeros(3, 3);
-#     zeros(3, 3) zeros(3, 3) zeros(3, 3) Matrix(I, 3, 3)]
-
-#     u_ss = sqrt(m*gc/4/k) * ones(4,)
-#     T(x) = [-sin(x[2]) 0 1;
-#             cos(x[2])*sin(x[3]) cos(x[3]) 0;
-#             cos(x[2])*cos(x[3]) -sin(x[3]) 0]
-#     R(x) = [cos(x[2])*cos(x[3]) sin(x[3])*sin(x[2]) -sin(x[2]);
-#             cos(x[3])*sin(x[2])*sin(x[1])-sin(x[3])*cos(x[1]) sin(x[3])*sin(x[2])*sin(x[1])+cos(x[3])*cos(x[1]) cos(x[2])*sin(x[1]);
-#             cos(x[3])*sin(x[2])*cos(x[1])-sin(x[3])*sin(x[1]) sin(x[3])*sin(x[2])*cos(x[1])+cos(x[3])*sin(x[1]) cos(x[2])*cos(x[1])]
-#     F(x) = vec([
-#         T(x) * x[4:6]
-#         Jinv * cross(-x[4:6], J * x[4:6])
-#         -cross(x[4:6], x[7:9]) + gc * R(x)' * [0; 0; 1]
-#         R(x) * x[7:9]
-#     ])
-
-#     if num == 1
-#         eff = Diagonal([lambda, 1, 1, 1])
-#     elseif num == 2
-#         eff = Diagonal([1, lambda, 1, 1])
-#     elseif num == 3
-#         eff = Diagonal([1, 1, lambda, 1])
-#     elseif num == 4
-#         eff = Diagonal([1, 1, 1, lambda])
-#     else
-#         error("Choose fauly actuator number")
-#     end
-
-#     f(x, u, p, t) = A*x + F(x) + B*(eff * u + u_ss).^2
-#     g(x, u, p, t) = C*x
-
-# 	# System dimension
-# 	n = size(A)[1]
-# 	m = size(B)[2]
-# 	l = size(C)[1]
-
-#     # Initial settings
-#     x0 = zeros(n,)
-#     u0 = zeros(m,)
-#     dt = 0.001
-#     tf = 1.0
-#     pr = zeros(4, 1)
-
-#     Wc = FTC.empirical_gramian(f, g, m, n, l; opt=:c, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
-#     Wo = FTC.empirical_gramian(f, g, m, n, l; opt=:o, dt=dt, tf=tf, pr=pr, xs=x0, us=u0)
-# 	minHSV = FTC.min_HSV(Wc, Wo)
-# end
-
-
-function compute_minHSV_squared(lambda, num::Int; dt=0.001, tf=1.0)
+function compute_minHSV_squared(lambda, num::Int; dt=0.01, tf=1.0)
     @assert lambda >= 0.0 && lambda <= 1.0
     Λ = diagm(ones(4))
     Λ[num, num] = lambda
@@ -178,13 +167,14 @@ function compute_minHSV_squared(lambda, num::Int; dt=0.001, tf=1.0)
 end
 
 function plotting(rotor_idx)
-    lambda = 0:0.20:1 |> collect
-    HSV_squareds = []
+    lambda = 0:0.10:1 |> collect
+    HSVs = []
     for i = 1:length(lambda)
-        HSV_squareds = push!(HSV_squareds, compute_minHSV_squared(lambda[i], rotor_idx))
+        HSVs = push!(HSVs, compute_minHSV_example(lambda[i], rotor_idx))
+        # HSVs = push!(HSVs, compute_minHSV_squared(lambda[i], rotor_idx))
     end
     return plot(lambda,
-                HSV_squareds,
+                HSVs,
                 xlabel = "Actuator effectiveness",
                 ylabel = "Minimum HSV_squareds",
                 label = nothing,

--- a/main/compute_gram_quadcopter.jl
+++ b/main/compute_gram_quadcopter.jl
@@ -163,7 +163,7 @@ function compute_minHSV_Islam(lambda, num::Int; dt=0.01, tf=1.0)
             error("Too large imaginary part")
         end
     end
-    min_HSV_squared = eigvals_Wc |> minimum |> sqrt # not min_HSV
+    min_HSV = eigvals_Wc |> minimum |> sqrt # not min_HSV
     # minHSV = FTC.min_HSV(Wc, Wo)
 end
 
@@ -177,7 +177,7 @@ function plotting(rotor_idx)
     return plot(lambda,
                 HSVs,
                 xlabel = "Actuator effectiveness",
-                ylabel = "Minimum HSV_squareds",
+                ylabel = "Minimum HSV",
                 label = nothing,
                )
 end

--- a/main/compute_gram_quadcopter.jl
+++ b/main/compute_gram_quadcopter.jl
@@ -163,7 +163,7 @@ function compute_minHSV_squared(lambda, num::Int; dt=0.01, tf=1.0)
             error("Too large imaginary part")
         end
     end
-    min_HSV_squared = eigvals_Wc |> minimum  # not min_HSV
+    min_HSV_squared = eigvals_Wc |> minimum |> sqrt # not min_HSV
     # minHSV = FTC.min_HSV(Wc, Wo)
 end
 


### PR DESCRIPTION
Partially resolves #71 

논문에 구현된 예제가 로터별 고장에 따라 다른 형상의 그래프가 나오던 것을 수정하였습니다..ㅎㅎ 
아래 결과 그래프를 참고해주세요.
저의 엄청난 실수(회전변환 행렬을 잘못 입력하였습니다ㅠ)로 혼란을 야기시킨 점 사과드립니다..

- 논문에 구현된 예제 쿼드콥터에 대한 결과 그래프
![image](https://user-images.githubusercontent.com/32696021/162616402-db3fa1ba-3632-4fa6-a7a9-db38d4098846.png)

### Notes
- `Wo`: observability gramian을 이용하지 않도록 수정하였습니다. 이 값을 사용해 `min_HSV`를 구하게 되면 observability에 따라 다른 그래프를 얻을 수 있습니다.
- `us`: Steady-state input을 의미하는 값으로 우리가 고려하는 문제에서는 0을 넣으면 되는 것으로 생각됩니다.
- 이 외에 필요해보이는 인자들: 아래 두 scales의 값 조정이 필요할 것 같습니다. 아마도 이것은 모델을 고려해서 적절한 값을 결정할 수 있을것으로 생각됩니다. 
  - `um`: Input perturbation scales
  - `xm`: Initial state perturbation scales
- `xm` default 1, `um` default 1로 설정한 결과(`islamQuadcopter`):
![image](https://user-images.githubusercontent.com/32696021/162616784-130ae1ca-2d96-41fd-a0f0-e0fd97354859.png)
- `xm` default 1, `um` 10000으로 설정한 결과(`islamQuadcopter`):
![image](https://user-images.githubusercontent.com/32696021/162617044-4413ee6f-3f5b-415a-a58e-ad269633c489.png)

P.S. 위 파라미터를 조정할 수 있도록 `FaultTolerantControl/src/reconfigurability.jl` 수정할 예정